### PR TITLE
Escape dynamic URLs in news cards

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -91,21 +91,24 @@ function createNewsCard(news, index) {
     const animationDelay = index * 0.1;
     
     // 이미지 HTML 생성
+    const safeImageUrl = news.image ? escapeHtml(news.image) : '';
     const imageHtml = news.image ? `
         <div class="news-image-container">
-            <img src="${escapeHtml(news.image)}" 
-                 alt="${escapeHtml(news.title)}" 
+            <img src="${safeImageUrl}"
+                 alt="${escapeHtml(news.title)}"
                  class="news-image"
                  onerror="this.style.display='none';"
                  loading="lazy">
         </div>
     ` : '';
-    
+
+    const safeLink = news.link ? escapeHtml(news.link) : '#';
+
     col.innerHTML = `
         <div class="news-card" style="animation-delay: ${animationDelay}s">
             ${imageHtml}
             <div class="news-content">
-                <a href="${news.link}" target="_blank" rel="noopener" class="news-title">
+                <a href="${safeLink}" target="_blank" rel="noopener" class="news-title">
                     ${escapeHtml(news.title)}
                 </a>
                 <div class="news-meta">


### PR DESCRIPTION
## Summary
- escape dynamic news card links with the existing HTML escape helper
- reuse the escaped image URL when rendering thumbnails
- provide a safe fallback when news items do not include a link

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915976a1f0c8327939c973dab3e75c8)