### PR TITLE
Refactor RSS utility module

### DIFF
--- a/news.py
+++ b/news.py
@@ -1,8 +1,273 @@
+"""Google 뉴스 RSS 검색 유틸리티 모듈.
+
+이 모듈은 Google 뉴스 RSS 피드에서 특정 검색어에 대한 기사 목록을 가져오는
+도우미 함수를 제공한다. 모든 함수와 클래스는 유지보수를 고려해 타입 힌트를
+포함하며, 예외 상황을 명확하게 처리한다.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+from dataclasses import asdict, dataclass
+from typing import Any, Iterable, List
+from urllib.parse import quote
+
 import feedparser
 
-query = "ai"
-feed_url = f"https://news.google.com/rss/search?q={query}&hl=ko&gl=KR&ceid=KR:ko"
-feed = feedparser.parse(feed_url)
 
-for entry in feed.entries:
-    print(entry.title, entry.link)
+logger = logging.getLogger(__name__)
+
+
+DEFAULT_QUERY: str = "ai"
+DEFAULT_LANGUAGE: str = "ko"
+DEFAULT_REGION: str = "KR"
+
+
+@dataclass(slots=True)
+class NewsArticle:
+    """RSS 항목을 표현하는 데이터 구조.
+
+    Attributes:
+        title: 기사 제목.
+        link: 기사 원문 URL.
+        published: 게시 시각 정보(존재하지 않을 경우 ``None``).
+        summary: 기사 요약(존재하지 않을 경우 ``None``).
+        source: 기사 출처(존재하지 않을 경우 ``None``).
+        image: 대표 이미지 URL(확인되지 않으면 ``None``).
+    """
+
+    title: str
+    link: str
+    published: str | None = None
+    summary: str | None = None
+    source: str | None = None
+    image: str | None = None
+
+
+def _clean_query(query: str | None) -> str:
+    """검색어를 정제하고 검증한다.
+
+    Args:
+        query: 사용자가 입력한 검색어. ``None``이면 기본 검색어를 사용한다.
+
+    Returns:
+        공백이 제거된 검증된 검색어 문자열.
+
+    Raises:
+        ValueError: 검색어가 비어 있는 경우.
+    """
+
+    candidate: str = (query or DEFAULT_QUERY).strip()
+    if not candidate:
+        raise ValueError("검색어는 최소 1자 이상 입력해야 합니다.")
+    return candidate
+
+
+def _get_entry_value(entry: Any, key: str) -> Any:
+    """엔트리에서 키에 해당하는 값을 추출한다.
+
+    Args:
+        entry: RSS 엔트리 객체.
+        key: 추출하려는 필드명.
+
+    Returns:
+        키에 해당하는 값. 존재하지 않으면 ``None``.
+    """
+
+    if hasattr(entry, "get"):
+        return entry.get(key)
+    return getattr(entry, key, None)
+
+
+def _extract_image(entry: Any) -> str | None:
+    """RSS 엔트리에서 이미지 URL을 추출한다.
+
+    Args:
+        entry: feedparser가 반환한 RSS 엔트리 객체.
+
+    Returns:
+        추출된 이미지 URL. 이미지가 없으면 ``None``.
+    """
+
+    media_content = _get_entry_value(entry, "media_content") or []
+    for media in media_content:
+        media_type: str = media.get("type", "")
+        if media_type.startswith("image/"):
+            return media.get("url")
+
+    media_thumbnail = _get_entry_value(entry, "media_thumbnail") or []
+    if media_thumbnail:
+        return media_thumbnail[0].get("url")
+
+    enclosures = _get_entry_value(entry, "enclosures") or []
+    for enclosure in enclosures:
+        enclosure_type: str = enclosure.get("type", "")
+        if enclosure_type.startswith("image/"):
+            return enclosure.get("href")
+
+    summary: str | None = _get_entry_value(entry, "summary")
+    if summary:
+        match = re.search(r"<img[^>]+src=[\"']([^\"']+)[\"']", summary)
+        if match:
+            return match.group(1)
+
+    return None
+
+
+def _build_feed_url(query: str, language: str, region: str) -> str:
+    """Google 뉴스 RSS URL을 생성한다.
+
+    Args:
+        query: 검색어 문자열.
+        language: Google 뉴스 언어 코드.
+        region: Google 뉴스 지역 코드.
+
+    Returns:
+        완성된 RSS 피드 URL.
+    """
+
+    encoded_query: str = quote(query)
+    return f"https://news.google.com/rss/search?q={encoded_query}&hl={language}&gl={region}&ceid={region}:{language}"
+
+
+def _convert_entries(entries: Iterable[Any]) -> List[NewsArticle]:
+    """feedparser 엔트리를 `NewsArticle` 목록으로 변환한다.
+
+    Args:
+        entries: feedparser가 반환한 엔트리 반복자.
+
+    Returns:
+        `NewsArticle` 객체 목록.
+    """
+
+    articles: List[NewsArticle] = []
+    for entry in entries:
+        title: str = _get_entry_value(entry, "title") or ""
+        link: str = _get_entry_value(entry, "link") or ""
+        published: str | None = _get_entry_value(entry, "published")
+        summary: str | None = _get_entry_value(entry, "summary")
+        source_info: Any = _get_entry_value(entry, "source")
+        if isinstance(source_info, dict):
+            source_title = source_info.get("title")
+        else:
+            source_title = getattr(source_info, "title", None)
+
+        article = NewsArticle(
+            title=title,
+            link=link,
+            published=published,
+            summary=summary,
+            source=source_title,
+            image=_extract_image(entry),
+        )
+        articles.append(article)
+    return articles
+
+
+def fetch_news(
+    query: str | None = None,
+    *,
+    language: str = DEFAULT_LANGUAGE,
+    region: str = DEFAULT_REGION,
+) -> List[NewsArticle]:
+    """Google 뉴스에서 검색 결과를 가져온다.
+
+    Args:
+        query: 검색어. ``None``이면 기본 검색어를 사용한다.
+        language: Google 뉴스 언어 코드(기본: ``ko``).
+        region: Google 뉴스 지역 코드(기본: ``KR``).
+
+    Returns:
+        `NewsArticle` 인스턴스 목록.
+
+    Raises:
+        ValueError: 검색어가 비어 있는 경우.
+        RuntimeError: 피드 파싱 중 예기치 못한 오류가 발생한 경우.
+    """
+
+    cleaned_query: str = _clean_query(query)
+    feed_url: str = _build_feed_url(cleaned_query, language, region)
+
+    logger.debug("Fetching RSS feed: %s", feed_url)
+    feed = feedparser.parse(feed_url)
+
+    if getattr(feed, "bozo", False):
+        bozo_exception: Exception | None = getattr(feed, "bozo_exception", None)
+        logger.error("RSS 피드 파싱 오류: %s", bozo_exception)
+        if isinstance(bozo_exception, Exception):
+            raise RuntimeError("RSS 피드를 파싱하는 중 오류가 발생했습니다.") from bozo_exception
+        raise RuntimeError("RSS 피드를 파싱하는 중 오류가 발생했습니다.")
+
+    entries: Iterable[Any] = getattr(feed, "entries", [])
+    return _convert_entries(entries)
+
+
+def _configure_logging(verbose: bool) -> None:
+    """로깅을 설정한다.
+
+    Args:
+        verbose: 디버그 로그 사용 여부.
+    """
+
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(levelname)s:%(name)s:%(message)s")
+
+
+def _parse_args() -> argparse.Namespace:
+    """CLI 인자를 파싱한다.
+
+    Returns:
+        파싱된 명령행 인자를 담은 네임스페이스.
+    """
+
+    parser = argparse.ArgumentParser(description="Google 뉴스 RSS 검색 도구")
+    parser.add_argument("query", nargs="?", default=None, help="검색어 (기본: ai)")
+    parser.add_argument("--language", "-l", default=DEFAULT_LANGUAGE, help="언어 코드 (기본: ko)")
+    parser.add_argument("--region", "-r", default=DEFAULT_REGION, help="지역 코드 (기본: KR)")
+    parser.add_argument("--verbose", "-v", action="store_true", help="디버그 로그 출력")
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        help="출력할 기사 수 제한",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI 진입점.
+
+    Raises:
+        SystemExit: 입력 오류 또는 RSS 파싱 오류가 발생한 경우.
+    """
+
+    args = _parse_args()
+    _configure_logging(args.verbose)
+
+    try:
+        articles = fetch_news(args.query, language=args.language, region=args.region)
+    except ValueError as validation_error:
+        logger.error("입력 오류: %s", validation_error)
+        raise SystemExit(1) from validation_error
+    except RuntimeError as runtime_error:
+        logger.error("뉴스를 가져오는 중 문제가 발생했습니다: %s", runtime_error)
+        raise SystemExit(2) from runtime_error
+
+    serialized_articles = [asdict(article) for article in articles]
+    if args.limit is not None:
+        serialized_articles = serialized_articles[: args.limit]
+
+    output = {
+        "query": args.query or DEFAULT_QUERY,
+        "count": len(serialized_articles),
+        "articles": serialized_articles,
+    }
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -1,0 +1,79 @@
+"""`news` 모듈 단위 테스트."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import pytest
+
+import news
+
+
+class DummyFeed:
+    """feedparser.parse가 반환하는 객체를 모사한다."""
+
+    def __init__(self, *, entries: List[Any], bozo: bool = False, bozo_exception: Exception | None = None) -> None:
+        self.entries = entries
+        self.bozo = bozo
+        self.bozo_exception = bozo_exception
+
+
+def _make_entry(data: Dict[str, Any]) -> SimpleNamespace:
+    """feedparser의 FeedParserDict와 유사한 객체를 만든다."""
+
+    return SimpleNamespace(**data)
+
+
+def test_fetch_news_returns_articles(monkeypatch: pytest.MonkeyPatch) -> None:
+    """정상적인 피드에서 뉴스 목록을 반환한다."""
+
+    entries = [
+        _make_entry(
+            {
+                "title": "테스트 뉴스",
+                "link": "https://example.com/article",
+                "published": "2024-01-01",
+                "summary": "<p>요약</p>",
+                "source": {"title": "Example"},
+                "media_content": [{"type": "image/png", "url": "https://example.com/image.png"}],
+            }
+        )
+    ]
+
+    monkeypatch.setattr(news.feedparser, "parse", lambda _: DummyFeed(entries=entries))
+
+    articles = news.fetch_news("test")
+
+    assert len(articles) == 1
+    article = articles[0]
+    assert article.title == "테스트 뉴스"
+    assert article.link == "https://example.com/article"
+    assert article.published == "2024-01-01"
+    assert article.summary == "<p>요약</p>"
+    assert article.source == "Example"
+    assert article.image == "https://example.com/image.png"
+
+
+def test_fetch_news_raises_on_empty_query() -> None:
+    """빈 검색어가 주어지면 ValueError를 발생시킨다."""
+
+    with pytest.raises(ValueError):
+        news.fetch_news("   ")
+
+
+def test_fetch_news_raises_on_bozo(monkeypatch: pytest.MonkeyPatch) -> None:
+    """RSS 파싱 오류(bozo)가 발생하면 RuntimeError를 발생시킨다."""
+
+    dummy_exception = RuntimeError("파싱 실패")
+    monkeypatch.setattr(
+        news.feedparser,
+        "parse",
+        lambda _: DummyFeed(entries=[], bozo=True, bozo_exception=dummy_exception),
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        news.fetch_news("test")
+
+    assert "RSS 피드를 파싱" in str(exc_info.value)
+


### PR DESCRIPTION
## Summary
- refactor the standalone news fetcher into a reusable utility with robust validation and logging
- add a CLI interface that outputs structured JSON responses
- create unit tests covering normal feeds, validation failures, and parser errors

## Testing
- pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170abded58832793846a58c25b16da)